### PR TITLE
Add SIWE authentication and basic user accounts

### DIFF
--- a/app/advertise/page.tsx
+++ b/app/advertise/page.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import { useState } from 'react'
+import { useSession } from 'next-auth/react'
+
+export default function Advertise() {
+  const { data: session } = useSession()
+  const [title, setTitle] = useState('')
+  const [rate, setRate] = useState('')
+  const [desc, setDesc] = useState('')
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault()
+    await fetch('/api/services', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, rate, desc }),
+    })
+    window.location.href = '/services'
+  }
+
+  if (!session?.address) {
+    return <div className="card"><p>Please sign in to advertise a service.</p></div>
+  }
+
+  return (
+    <div className="card">
+      <h2>Advertise a service</h2>
+      <form onSubmit={submit}>
+        <div style={{display: 'grid', gap: 12}}>
+          <label>Title <br/><input value={title} onChange={e=>setTitle(e.target.value)} placeholder="e.g., Smart contract audit" /></label>
+          <label>Rate (USDC) <br/><input value={rate} onChange={e=>setRate(e.target.value)} placeholder="e.g., 100/hr" /></label>
+          <label>Description <br/><textarea value={desc} onChange={e=>setDesc(e.target.value)} rows={6} placeholder="What do you offer?"/></label>
+        </div>
+        <div style={{marginTop: 14}}>
+          <button className="btn" type="submit">Create</button>
+          <a className="btn secondary" href="/">Cancel</a>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,43 @@
+import NextAuth from 'next-auth'
+import CredentialsProvider from 'next-auth/providers/credentials'
+import { SiweMessage } from 'siwe'
+import { cookies } from 'next/headers'
+
+export const authOptions = {
+  providers: [
+    CredentialsProvider({
+      name: 'Ethereum',
+      credentials: {
+        message: { label: 'Message', type: 'text' },
+        signature: { label: 'Signature', type: 'text' },
+      },
+      async authorize(credentials) {
+        try {
+          const siwe = new SiweMessage(JSON.parse(credentials?.message || '{}'))
+          const nonce = cookies().get('nonce')?.value
+          const result = await siwe.verify({ signature: credentials?.signature || '', nonce })
+          if (result.success) {
+            return { id: siwe.address }
+          }
+          return null
+        } catch {
+          return null
+        }
+      },
+    }),
+  ],
+  session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.sub = user.id
+      return token
+    },
+    async session({ session, token }) {
+      ;(session as any).address = token.sub
+      return session
+    },
+  },
+}
+
+const handler = NextAuth(authOptions)
+export { handler as GET, handler as POST }

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,43 +1,5 @@
 import NextAuth from 'next-auth'
-import CredentialsProvider from 'next-auth/providers/credentials'
-import { SiweMessage } from 'siwe'
-import { cookies } from 'next/headers'
-
-export const authOptions = {
-  providers: [
-    CredentialsProvider({
-      name: 'Ethereum',
-      credentials: {
-        message: { label: 'Message', type: 'text' },
-        signature: { label: 'Signature', type: 'text' },
-      },
-      async authorize(credentials) {
-        try {
-          const siwe = new SiweMessage(JSON.parse(credentials?.message || '{}'))
-          const nonce = cookies().get('nonce')?.value
-          const result = await siwe.verify({ signature: credentials?.signature || '', nonce })
-          if (result.success) {
-            return { id: siwe.address }
-          }
-          return null
-        } catch {
-          return null
-        }
-      },
-    }),
-  ],
-  session: { strategy: 'jwt' },
-  callbacks: {
-    async jwt({ token, user }) {
-      if (user) token.sub = user.id
-      return token
-    },
-    async session({ session, token }) {
-      ;(session as any).address = token.sub
-      return session
-    },
-  },
-}
+import { authOptions } from '../../../../lib/auth'
 
 const handler = NextAuth(authOptions)
 export { handler as GET, handler as POST }

--- a/app/api/auth/nonce/route.ts
+++ b/app/api/auth/nonce/route.ts
@@ -1,0 +1,9 @@
+import { NextResponse } from 'next/server'
+import { randomBytes } from 'crypto'
+
+export async function GET() {
+  const nonce = randomBytes(16).toString('base64')
+  const res = NextResponse.json({ nonce })
+  res.cookies.set('nonce', nonce, { httpOnly: true, sameSite: 'lax' })
+  return res
+}

--- a/app/api/jobs/route.ts
+++ b/app/api/jobs/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
-import { authOptions } from '../auth/[...nextauth]/route'
+import { authOptions } from '../../../lib/auth'
 import { jobs, Job } from '../../../lib/data'
 
 export async function GET() {

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
-import { authOptions } from '../auth/[...nextauth]/route'
+import { authOptions } from '../../../lib/auth'
 import { services, Service } from '../../../lib/data'
 
 export async function GET() {

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -1,10 +1,10 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
 import { authOptions } from '../auth/[...nextauth]/route'
-import { jobs, Job } from '../../../lib/data'
+import { services, Service } from '../../../lib/data'
 
 export async function GET() {
-  return NextResponse.json(jobs)
+  return NextResponse.json(services)
 }
 
 export async function POST(req: Request) {
@@ -13,15 +13,16 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
   const data = await req.json()
-  if (!data.title || !data.budget || !data.desc) {
+  if (!data.title || !data.rate || !data.desc) {
     return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
   }
-  const job: Job = {
+  const service: Service = {
     id: crypto.randomUUID(),
     title: data.title,
-    budget: data.budget,
+    rate: data.rate,
     desc: data.desc,
+    user: session.address,
   }
-  jobs.push(job)
-  return NextResponse.json(job, { status: 201 })
+  services.push(service)
+  return NextResponse.json(service, { status: 201 })
 }

--- a/app/api/skills/endorse/route.ts
+++ b/app/api/skills/endorse/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
-import { authOptions } from '../../auth/[...nextauth]/route'
+import { authOptions } from '../../../../lib/auth'
 import { skills } from '../../../../lib/data'
 
 export async function POST(req: Request) {

--- a/app/api/skills/endorse/route.ts
+++ b/app/api/skills/endorse/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../../auth/[...nextauth]/route'
+import { skills } from '../../../../lib/data'
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session?.address) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const data = await req.json()
+  const skill = skills.find(s => s.user === data.user && s.name === data.name)
+  if (!skill) {
+    return NextResponse.json({ error: 'Skill not found' }, { status: 404 })
+  }
+  if (!skill.endorsements.includes(session.address)) {
+    skill.endorsements.push(session.address)
+  }
+  return NextResponse.json(skill)
+}

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { getServerSession } from 'next-auth'
-import { authOptions } from '../auth/[...nextauth]/route'
+import { authOptions } from '../../../lib/auth'
 import { skills, Skill } from '../../../lib/data'
 
 export async function GET(req: Request) {

--- a/app/api/skills/route.ts
+++ b/app/api/skills/route.ts
@@ -1,0 +1,28 @@
+import { NextResponse } from 'next/server'
+import { getServerSession } from 'next-auth'
+import { authOptions } from '../auth/[...nextauth]/route'
+import { skills, Skill } from '../../../lib/data'
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url)
+  const user = searchParams.get('user')
+  const result = user ? skills.filter(s => s.user === user) : skills
+  return NextResponse.json(result)
+}
+
+export async function POST(req: Request) {
+  const session = await getServerSession(authOptions)
+  if (!session?.address) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+  }
+  const data = await req.json()
+  if (!data.name) {
+    return NextResponse.json({ error: 'Missing fields' }, { status: 400 })
+  }
+  let skill = skills.find(s => s.user === session.address && s.name === data.name)
+  if (!skill) {
+    skill = { user: session.address, name: data.name, endorsements: [] }
+    skills.push(skill)
+  }
+  return NextResponse.json(skill, { status: 201 })
+}

--- a/app/jobs/page.tsx
+++ b/app/jobs/page.tsx
@@ -1,4 +1,4 @@
-import type { Job } from '../api/jobs/route'
+import type { Job } from '../../lib/data'
 import { headers } from 'next/headers'
 
 export const dynamic = 'force-dynamic'

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
 import './globals.css'
 import type { Metadata } from 'next'
+import Providers from './providers'
+import AuthButton from '../components/AuthButton'
 
 export const metadata: Metadata = {
   title: 'w3rk.net — Onchain tasking, UBI-ready',
@@ -17,22 +19,28 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
   return (
     <html lang="en">
       <body>
-        <header className="header">
-          <div className="brand">
-            <span className="brand-dot" />
-            w3rk<span style={{opacity:0.7}}>.net</span>
-          </div>
-          <nav className="nav">
-            <a href="/jobs">Jobs</a>
-            <a href="/post">Post a job</a>
-            <a href="/profile">Profile</a>
-            <a href="/about">About</a>
-          </nav>
-        </header>
-        <main className="container">{children}</main>
-        <footer className="footer small">
-          © {new Date().getFullYear()} w3rk.net — Onchain work, built for Base.
-        </footer>
+        <Providers>
+          <header className="header">
+            <div className="brand">
+              <span className="brand-dot" />
+              w3rk<span style={{opacity:0.7}}>.net</span>
+            </div>
+            <nav className="nav">
+              <a href="/jobs">Jobs</a>
+              <a href="/post">Post a job</a>
+              <a href="/services">Services</a>
+              <a href="/advertise">Advertise</a>
+              <a href="/skills">Skills</a>
+              <a href="/profile">Profile</a>
+              <a href="/about">About</a>
+              <AuthButton />
+            </nav>
+          </header>
+          <main className="container">{children}</main>
+          <footer className="footer small">
+            © {new Date().getFullYear()} w3rk.net — Onchain work, built for Base.
+          </footer>
+        </Providers>
       </body>
     </html>
   )

--- a/app/post/page.tsx
+++ b/app/post/page.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { useState } from 'react'
+import { useSession } from 'next-auth/react'
 
 export default function PostJob() {
+  const { data: session } = useSession()
   const [title, setTitle] = useState('')
   const [budget, setBudget] = useState('')
   const [desc, setDesc] = useState('')
@@ -15,6 +17,10 @@ export default function PostJob() {
       body: JSON.stringify({ title, budget, desc }),
     })
     window.location.href = '/jobs'
+  }
+
+  if (!session?.address) {
+    return <div className="card"><p>Please sign in to post a job.</p></div>
   }
 
   return (

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,8 +1,48 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { useSession } from 'next-auth/react'
+import type { Skill } from '../../lib/data'
+
 export default function Profile() {
+  const { data: session } = useSession()
+  const [skill, setSkill] = useState('')
+  const [skills, setSkills] = useState<Skill[]>([])
+
+  useEffect(() => {
+    if (session?.address) {
+      fetch(`/api/skills?user=${session.address}`).then(r => r.json()).then(setSkills)
+    }
+  }, [session])
+
+  async function addSkill(e: React.FormEvent) {
+    e.preventDefault()
+    await fetch('/api/skills', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: skill }),
+    })
+    setSkill('')
+    const res = await fetch(`/api/skills?user=${session?.address}`)
+    setSkills(await res.json())
+  }
+
+  if (!session?.address) {
+    return <div className="card"><p>Please sign in to manage your profile.</p></div>
+  }
+
   return (
     <div className="card">
       <h2>Your Profile</h2>
-      <p>Active Seeker Dividend (ASD) info will appear here once UBI contracts are live.</p>
+      <form onSubmit={addSkill} style={{marginTop:12}}>
+        <label>New Skill<br/><input value={skill} onChange={e=>setSkill(e.target.value)} /></label>
+        <button className="btn small" type="submit" style={{marginLeft:8}}>Add</button>
+      </form>
+      <ul style={{marginTop:20}}>
+        {skills.map(s => (
+          <li key={s.name}>{s.name} — {s.endorsements.length} endorsement(s)</li>
+        ))}
+      </ul>
     </div>
   )
 }

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,7 @@
+'use client'
+
+import { SessionProvider } from 'next-auth/react'
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  return <SessionProvider>{children}</SessionProvider>
+}

--- a/app/services/page.tsx
+++ b/app/services/page.tsx
@@ -1,0 +1,30 @@
+import type { Service } from '../../lib/data'
+import { headers } from 'next/headers'
+
+export const dynamic = 'force-dynamic'
+
+export default async function Services() {
+  const host = headers().get('host') ?? 'localhost:3000'
+  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
+  const res = await fetch(`${protocol}://${host}/api/services`, { cache: 'no-store' })
+  const services: Service[] = await res.json()
+
+  return (
+    <div className="card">
+      <h2>Services</h2>
+      {services.length === 0 ? (
+        <p className="small">No services advertised yet.</p>
+      ) : (
+        <ul style={{marginTop:20}} className="grid">
+          {services.map(s => (
+            <li key={s.id} className="card" style={{listStyle:'none'}}>
+              <strong>{s.title}</strong>
+              <div className="small">Rate: {s.rate}</div>
+              <p className="small">{s.desc}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -1,0 +1,32 @@
+import { headers } from 'next/headers'
+import type { Skill } from '../../lib/data'
+import EndorseButton from '../../components/EndorseButton'
+
+export const dynamic = 'force-dynamic'
+
+export default async function SkillsPage() {
+  const host = headers().get('host') ?? 'localhost:3000'
+  const protocol = process.env.NODE_ENV === 'development' ? 'http' : 'https'
+  const res = await fetch(`${protocol}://${host}/api/skills`, { cache: 'no-store' })
+  const skills: Skill[] = await res.json()
+
+  return (
+    <div className="card">
+      <h2>Skills</h2>
+      {skills.length === 0 ? (
+        <p className="small">No skills claimed yet.</p>
+      ) : (
+        <ul style={{marginTop:20}} className="grid">
+          {skills.map(s => (
+            <li key={s.user + s.name} className="card" style={{listStyle:'none'}}>
+              <strong>{s.name}</strong>
+              <div className="small">User: {s.user}</div>
+              <div className="small">Endorsements: {s.endorsements.length}</div>
+              <EndorseButton user={s.user} name={s.name} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  )
+}

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -1,0 +1,36 @@
+'use client'
+
+import { useSession, signIn, signOut } from 'next-auth/react'
+import { SiweMessage } from 'siwe'
+
+export default function AuthButton() {
+  const { data: session, status } = useSession()
+
+  async function login() {
+    if (!window.ethereum) return
+    await window.ethereum.request({ method: 'eth_requestAccounts' })
+    const address = (await window.ethereum.request({ method: 'eth_accounts' }))[0]
+    const nonceRes = await fetch('/api/auth/nonce')
+    const { nonce } = await nonceRes.json()
+    const message = new SiweMessage({
+      domain: window.location.host,
+      address,
+      statement: 'Sign in with Ethereum to w3rk.net',
+      uri: window.location.origin,
+      version: '1',
+      chainId: 1,
+      nonce,
+    })
+    const signature = await window.ethereum.request({
+      method: 'personal_sign',
+      params: [message.prepareMessage(), address],
+    })
+    await signIn('credentials', { message: JSON.stringify(message), signature }, { redirect: false })
+  }
+
+  if (status === 'loading') return null
+  if (session?.address) {
+    return <button className="btn small" onClick={() => signOut()}>Sign out</button>
+  }
+  return <button className="btn small" onClick={login}>Sign in</button>
+}

--- a/components/AuthButton.tsx
+++ b/components/AuthButton.tsx
@@ -7,9 +7,10 @@ export default function AuthButton() {
   const { data: session, status } = useSession()
 
   async function login() {
-    if (!window.ethereum) return
-    await window.ethereum.request({ method: 'eth_requestAccounts' })
-    const address = (await window.ethereum.request({ method: 'eth_accounts' }))[0]
+    const { ethereum } = window as any
+    if (!ethereum) return
+    await ethereum.request({ method: 'eth_requestAccounts' })
+    const address = (await ethereum.request({ method: 'eth_accounts' }))[0]
     const nonceRes = await fetch('/api/auth/nonce')
     const { nonce } = await nonceRes.json()
     const message = new SiweMessage({
@@ -21,11 +22,11 @@ export default function AuthButton() {
       chainId: 1,
       nonce,
     })
-    const signature = await window.ethereum.request({
+    const signature = await ethereum.request({
       method: 'personal_sign',
       params: [message.prepareMessage(), address],
     })
-    await signIn('credentials', { message: JSON.stringify(message), signature }, { redirect: false })
+    await signIn('credentials', { message: JSON.stringify(message), signature, redirect: false })
   }
 
   if (status === 'loading') return null

--- a/components/EndorseButton.tsx
+++ b/components/EndorseButton.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { useSession } from 'next-auth/react'
+
+export default function EndorseButton({ user, name }: { user: string; name: string }) {
+  const { data: session } = useSession()
+  async function endorse() {
+    await fetch('/api/skills/endorse', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ user, name }),
+    })
+    window.location.reload()
+  }
+  if (!session?.address || session.address === user) return null
+  return <button className="btn small" onClick={endorse}>Endorse</button>
+}

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,0 +1,44 @@
+import { AuthOptions } from 'next-auth'
+import CredentialsProvider from 'next-auth/providers/credentials'
+import { SiweMessage } from 'siwe'
+import { cookies } from 'next/headers'
+
+export const authOptions: AuthOptions = {
+  providers: [
+    CredentialsProvider({
+      name: 'Ethereum',
+      credentials: {
+        message: { label: 'Message', type: 'text' },
+        signature: { label: 'Signature', type: 'text' },
+      },
+      async authorize(credentials) {
+        try {
+          const siwe = new SiweMessage(JSON.parse(credentials?.message || '{}'))
+          const nonce = cookies().get('nonce')?.value
+          const result = await siwe.verify({
+            signature: credentials?.signature || '',
+            nonce,
+          })
+          if (result.success) {
+            return { id: siwe.address }
+          }
+          return null
+        } catch {
+          return null
+        }
+      },
+    }),
+  ],
+  session: { strategy: 'jwt' },
+  callbacks: {
+    async jwt({ token, user }) {
+      if (user) token.sub = (user as any).id
+      return token
+    },
+    async session({ session, token }) {
+      ;(session as any).address = token.sub
+      return session
+    },
+  },
+}
+

--- a/lib/data.ts
+++ b/lib/data.ts
@@ -1,0 +1,26 @@
+export type Job = {
+  id: string;
+  title: string;
+  budget: string;
+  desc: string;
+};
+
+export const jobs: Job[] = [];
+
+export type Service = {
+  id: string;
+  title: string;
+  rate: string;
+  desc: string;
+  user: string;
+};
+
+export const services: Service[] = [];
+
+export type Skill = {
+  user: string;
+  name: string;
+  endorsements: string[];
+};
+
+export const skills: Skill[] = [];

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,7 @@
+import NextAuth from 'next-auth'
+
+declare module 'next-auth' {
+  interface Session {
+    address?: string
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "^14.2.32",
+        "next-auth": "^4.24.7",
         "react": "18.3.1",
-        "react-dom": "18.3.1"
+        "react-dom": "18.3.1",
+        "siwe": "^2.1.5"
       },
       "devDependencies": {
         "@types/node": "20.12.12",
@@ -19,6 +21,22 @@
         "eslint": "8.57.0",
         "eslint-config-next": "14.2.5",
         "typescript": "5.5.4"
+      }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -376,6 +394,31 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -424,6 +467,15 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@panva/hkdf": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@panva/hkdf/-/hkdf-1.2.1.tgz",
+      "integrity": "sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -447,6 +499,49 @@
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.12.0.tgz",
       "integrity": "sha512-5EwMtOqvJMMa3HbmxLlF74e+3/HhwBTMcvt3nqVJgGCozO6hzIPOBlwm8mGVNR9SN2IJpxSnlxczyDjcn7qIyw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@spruceid/siwe-parser": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@spruceid/siwe-parser/-/siwe-parser-2.1.2.tgz",
+      "integrity": "sha512-d/r3S1LwJyMaRAKQ0awmo9whfXeE88Qt00vRj91q5uv5ATtWIQEGJ67Yr5eSZw5zp1/fZCXZYuEckt8lSkereQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@noble/hashes": "^1.1.2",
+        "apg-js": "^4.3.0",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      }
+    },
+    "node_modules/@stablelib/binary": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/binary/-/binary-1.0.1.tgz",
+      "integrity": "sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/int": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/int": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/int/-/int-1.0.1.tgz",
+      "integrity": "sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==",
+      "license": "MIT"
+    },
+    "node_modules/@stablelib/random": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+      "integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/binary": "^1.0.1",
+        "@stablelib/wipe": "^1.0.1"
+      }
+    },
+    "node_modules/@stablelib/wipe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/wipe/-/wipe-1.0.1.tgz",
+      "integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==",
       "license": "MIT"
     },
     "node_modules/@swc/counter": {
@@ -962,6 +1057,13 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -1004,6 +1106,12 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/apg-js": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/apg-js/-/apg-js-4.4.0.tgz",
+      "integrity": "sha512-fefmXFknJmtgtNEXfPwZKYkMFX4Fyeyz+fNF6JWp87biGOPslJbCBVU158zvKRZfHBKnJDy8CMM40oLFGkXT8Q==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1416,6 +1524,15 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -2252,6 +2369,59 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ethers": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.15.0.tgz",
+      "integrity": "sha512-Kf/3ZW54L4UT0pZtsY/rf+EkBU7Qi5nnhonjUb8yTXcxH3cdcWrV2cRyk0Xk/4jK6OoHhxxZHriyhje20If2hQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/ethers-io/"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "license": "0BSD",
+      "peer": true
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -3309,6 +3479,15 @@
         "@pkgjs/parseargs": "^0.11.0"
       }
     },
+    "node_modules/jose": {
+      "version": "4.15.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
+      "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -3629,6 +3808,44 @@
         }
       }
     },
+    "node_modules/next-auth": {
+      "version": "4.24.11",
+      "resolved": "https://registry.npmjs.org/next-auth/-/next-auth-4.24.11.tgz",
+      "integrity": "sha512-pCFXzIDQX7xmHFs4KVH4luCjaCbuPRtZ9oBUjUhOk84mZ9WVPf94n87TxYI4rSRf9HmfHEF8Yep3JrYDVOo3Cw==",
+      "license": "ISC",
+      "dependencies": {
+        "@babel/runtime": "^7.20.13",
+        "@panva/hkdf": "^1.0.2",
+        "cookie": "^0.7.0",
+        "jose": "^4.15.5",
+        "oauth": "^0.9.15",
+        "openid-client": "^5.4.0",
+        "preact": "^10.6.3",
+        "preact-render-to-string": "^5.1.19",
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@auth/core": "0.34.2",
+        "next": "^12.2.5 || ^13 || ^14 || ^15",
+        "nodemailer": "^6.6.5",
+        "react": "^17.0.2 || ^18 || ^19",
+        "react-dom": "^17.0.2 || ^18 || ^19"
+      },
+      "peerDependenciesMeta": {
+        "@auth/core": {
+          "optional": true
+        },
+        "nodemailer": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3637,6 +3854,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-hash": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/object-hash/-/object-hash-2.2.0.tgz",
+      "integrity": "sha512-gScRMn0bS5fH+IuwyIFgnh9zBdo4DV+6GhygmWM9HyNJSgS0hScp1f5vjtm7oIIOiT9trXrShAkLFSc2IqKNgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/object-inspect": {
@@ -3752,6 +3978,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/oidc-token-hash": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/oidc-token-hash/-/oidc-token-hash-5.1.1.tgz",
+      "integrity": "sha512-D7EmwxJV6DsEB6vOFLrBM2OzsVgQzgPWyHlV2OOAVj772n+WTXpudC9e9u5BVKQnYwaD30Ivhi9b+4UeBcGu9g==",
+      "license": "MIT",
+      "engines": {
+        "node": "^10.13.0 || >=12.0.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3760,6 +3995,33 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/openid-client": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/openid-client/-/openid-client-5.7.1.tgz",
+      "integrity": "sha512-jDBPgSVfTnkIh71Hg9pRvtJc6wTwqjRkN88+gCFtYWrlP4Yx2Dsrow8uPi3qLr/aeymPF3o2+dS+wOpglK04ew==",
+      "license": "MIT",
+      "dependencies": {
+        "jose": "^4.15.9",
+        "lru-cache": "^6.0.0",
+        "object-hash": "^2.2.0",
+        "oidc-token-hash": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/openid-client/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/optionator": {
@@ -3964,6 +4226,28 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/preact": {
+      "version": "10.27.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.27.1.tgz",
+      "integrity": "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/preact-render-to-string": {
+      "version": "5.2.6",
+      "resolved": "https://registry.npmjs.org/preact-render-to-string/-/preact-render-to-string-5.2.6.tgz",
+      "integrity": "sha512-JyhErpYOvBV1hEPwIxc/fHWXPfnEGdRKxc8gFdAZ7XV4tlzyzG847XAyEZqoDnynP88akM4eaHcSOzNcLWFguw==",
+      "license": "MIT",
+      "dependencies": {
+        "pretty-format": "^3.8.0"
+      },
+      "peerDependencies": {
+        "preact": ">=10"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3973,6 +4257,12 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "3.8.0",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-3.8.0.tgz",
+      "integrity": "sha512-WuxUnVtlWL1OfZFQFuqvnvs6MiAGk9UNsBostyBOB0Is9wb5uRESevA6rnl/rkksXaGX3GzZhPup5d6Vp1nFew==",
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -3990,7 +4280,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4444,6 +4733,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/siwe": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/siwe/-/siwe-2.3.2.tgz",
+      "integrity": "sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@spruceid/siwe-parser": "^2.1.2",
+        "@stablelib/random": "^1.0.1",
+        "uri-js": "^4.4.1",
+        "valid-url": "^1.0.9"
+      },
+      "peerDependencies": {
+        "ethers": "^5.6.8 || ^6.0.8"
       }
     },
     "node_modules/slash": {
@@ -5059,11 +5363,24 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/valid-url": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+      "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -5286,6 +5603,34 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "license": "ISC"
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -10,8 +10,10 @@
   },
   "dependencies": {
     "next": "^14.2.32",
+    "next-auth": "^4.24.7",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "siwe": "^2.1.5"
   },
   "devDependencies": {
     "@types/node": "20.12.12",


### PR DESCRIPTION
## Summary
- Implement Sign-In with Ethereum using NextAuth and SIWE
- Enable authenticated posting of jobs and service advertisements
- Add skills with endorsement functionality and navigation updates

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bb3bc4ef588323aa0f93f81a3ffe12