### PR TITLE
fix: add default next-auth secret

### DIFF
--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,9 +1,12 @@
 import { AuthOptions } from 'next-auth'
 import CredentialsProvider from 'next-auth/providers/credentials'
 import { SiweMessage } from 'siwe'
-import { cookies } from 'next/headers'
+import { randomBytes } from 'crypto'
+
+const secret = process.env.NEXTAUTH_SECRET ?? randomBytes(32).toString('hex')
 
 export const authOptions: AuthOptions = {
+  secret,
   providers: [
     CredentialsProvider({
       name: 'Ethereum',


### PR DESCRIPTION
## Summary
- set a default `NEXTAUTH_SECRET` to prevent runtime errors

## Testing
- `npm run build`
- `npm test` *(fails: Missing script "test")*
- `curl -i http://localhost:4000/api/auth/session`
- `curl -i -X POST http://localhost:4000/api/auth/_log -H 'Content-Type: application/json' -d '{}'`

------
https://chatgpt.com/codex/tasks/task_e_68bb4618c8548323aec6d92b92dc2a80